### PR TITLE
fix syntax error in validator.py

### DIFF
--- a/tests/validator.py
+++ b/tests/validator.py
@@ -87,7 +87,6 @@ class SpecifierValidatorBase:
 			{ 'name': 'group', 'required': True, 'datatype': str  },
 			{ 'name': 'position', 'required': True, 'datatype': str },
 			{ 'name': 'type', 'required': True, 'datatype': str },
-			{ 'name': 'group' , 'required': True, 'datatype': str }
 			{ 'name': 'subgroup', 'required': False, 'datatype': str },
 			{ 'name': 'comment', 'required': False, 'datatype': str },
 			{ 'name': 'samples', 'required': False, 'datatype': list[str] },


### PR DESCRIPTION
Fixes a syntax error that prevents validator.py from running.