### PR TITLE
Add note to ExpandBoolAsExecs about Pure functions

### DIFF
--- a/yaml/ufunction.yml
+++ b/yaml/ufunction.yml
@@ -397,6 +397,10 @@ specifiers:
     type-comment: name of enum parameter
     utility: 2
     position: meta
+    comment: |
+      Note that "ReturnValue" is a special string used to refer to the return value of the function.
+
+      If this is applied to a const method, you must also apply `BlueprintPure=false` because Unreal will make const methods pure, and pure methods cannot have exec pins.
     samples:
       - |
         UENUM()

--- a/yaml/ufunction.yml
+++ b/yaml/ufunction.yml
@@ -419,7 +419,10 @@ specifiers:
     type-comment: name of bool parameter
     utility: 2
     position: meta
-    comment: Note that "ReturnValue" is a special string used to refer to the return value of the function.
+    comment: |
+      Note that "ReturnValue" is a special string used to refer to the return value of the function.
+
+      If this is applied to a const method, you must also apply `BlueprintPure=false` because Unreal will make const methods pure, and pure methods cannot have exec pins.
     samples: 
     - |
       UFUNCTION(BlueprintCallable, meta=(ExpandBoolAsExecs="ReturnValue"))


### PR DESCRIPTION
Adds a note about a gotcha with `ExpandBoolAsExecs` that can cause no pins to appear at all for const methods. Engine uses this pattern on `UGameplayAbility::IsLocallyControlled`.